### PR TITLE
Align with the api provided by serde_json

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 [`serde-json`]: https://crates.io/crates/serde_json
 
+```toml
+[dependencies]
+serde-json-core = "0.0.1"
+```
+
 ## [Documentation](https://japaric.github.io/serde-json-core/serde_json_core/)
 
 ## License

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,3 +62,8 @@ extern crate serde_derive;
 
 pub mod de;
 pub mod ser;
+
+#[doc(inline)]
+pub use self::de::{from_slice, from_str};
+#[doc(inline)]
+pub use self::ser::{to_string, to_vec};


### PR DESCRIPTION
- Re-export to_* and from_* methods in the root of the crate
- Added a rust-toolchain file to set rustup to nightly by default
- Update README to make it explicit there is a crate published in crates.io

This merge request makes it easier to replace `serde_json` with `serde_json_core` when building with no_std.

Example:
```rust
#[cfg(not(feature = "std"))]
use serde_json_core as serde_json;
 
let deserialized = serde_json::from_str("...");
```