### PR TITLE
add f32/f64 serialization and deserialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ repository = "https://japaric.github.io/serde-json-core/serde_json_core"
 version = "0.0.1"
 
 [dependencies]
-heapless = "0.4.4"
+heapless = "0.4.0"
 
 [dependencies.serde]
 default-features = false
-version = "1.0.91"
+version = "1.0.80"
 
 [dev-dependencies]
-serde_derive = "1.0.91"
+serde_derive = "1.0.80"
 
 [features]
 std = ["serde/std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,19 @@ repository = "https://japaric.github.io/serde-json-core/serde_json_core"
 version = "0.0.1"
 
 [dependencies]
-heapless = "0.4.0"
+heapless = "0.4.4"
 
 [dependencies.serde]
 default-features = false
-version = "1.0.80"
+version = "1.0.91"
+
+[dependencies.lexical-core]
+default-features = false
+features = ["ryu"]
+version = "0.4.0"
 
 [dev-dependencies]
-serde_derive = "1.0.80"
+serde_derive = "1.0.91"
 
 [features]
 std = ["serde/std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,6 @@ heapless = "0.4.4"
 default-features = false
 version = "1.0.91"
 
-[dependencies.lexical-core]
-default-features = false
-features = ["ryu"]
-version = "0.4.0"
-
 [dev-dependencies]
 serde_derive = "1.0.91"
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -377,12 +377,12 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 },
                 Some(_) => {
                     let s = str::from_utf8(&self.slice[start..self.index])
-                        .or(Err(Error::InvalidUnicodeCodePoint))?;
+                        .or(Err(Error::InvalidNumber))?;
                     let v = f32::from_str(s)
                         .or(Err(Error::InvalidNumber))?;
                     return visitor.visit_f32(v);
                 },
-                None => return Err(Error::EofWhileParsingString),
+                None => return Err(Error::EofWhileParsingNumber),
             }
         }
     }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -391,7 +391,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         V: Visitor<'de>,
     {
         self.parse_whitespace().ok_or(Error::EofWhileParsingValue)?;
-        deserialize_fromstr!(self, visitor, f32, visit_f32, b"-0123456789.eE")
+        deserialize_fromstr!(self, visitor, f32, visit_f32, b"0123456789+-.eE")
     }
 
     fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value>
@@ -399,7 +399,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         V: Visitor<'de>,
     {
         self.parse_whitespace().ok_or(Error::EofWhileParsingValue)?;
-        deserialize_fromstr!(self, visitor, f64, visit_f64, b"-0123456789.eE")
+        deserialize_fromstr!(self, visitor, f64, visit_f64, b"0123456789+-.eE")
     }
 
     fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value>

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -1,12 +1,10 @@
 //! Serialize a Rust data structure into JSON data
 
-use core::{fmt, mem};
+use core::{fmt, fmt::Write, mem};
 
 use serde::ser;
 
 use heapless::{String, Vec};
-
-use lexical_core::{f32toa_slice, MAX_F32_SIZE};
 
 use self::seq::SerializeSeq;
 use self::struct_::SerializeStruct;
@@ -190,8 +188,9 @@ where
     }
 
     fn serialize_f32(self, v: f32) -> Result<Self::Ok> {
-        let mut s: [u8; MAX_F32_SIZE] = [0; MAX_F32_SIZE];
-        self.buf.extend_from_slice(f32toa_slice(v, &mut s))?;
+        let mut s: String<heapless::consts::U32> = String::new();
+        write!(&mut s, "{}", v).unwrap();
+        self.buf.extend_from_slice(s.as_bytes())?;
         Ok(())
     }
 
@@ -515,7 +514,7 @@ mod tests {
 
         assert_eq!(
             &*crate::to_string::<N, _>(&Temperature { temperature: -20. }).unwrap(),
-            r#"{"temperature":-20.0}"#
+            r#"{"temperature":-20}"#
         );
     }
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -189,7 +189,7 @@ where
 
     fn serialize_f32(self, v: f32) -> Result<Self::Ok> {
         let mut s: String<heapless::consts::U32> = String::new();
-        write!(&mut s, "{}", v).unwrap();
+        write!(&mut s, "{:e}", v).unwrap();
         self.buf.extend_from_slice(s.as_bytes())?;
         Ok(())
     }
@@ -514,7 +514,17 @@ mod tests {
 
         assert_eq!(
             &*crate::to_string::<N, _>(&Temperature { temperature: -20. }).unwrap(),
-            r#"{"temperature":-20}"#
+            r#"{"temperature":-2e1}"#
+        );
+
+        assert_eq!(
+            &*crate::to_string::<N, _>(&Temperature { temperature: -20.345 }).unwrap(),
+            r#"{"temperature":-2.0345e1}"#
+        );
+
+        assert_eq!(
+            &*crate::to_string::<N, _>(&Temperature { temperature: -20.3456789e-30 }).unwrap(),
+            r#"{"temperature":-2.0345679e-29}"#
         );
     }
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -126,7 +126,7 @@ macro_rules! serialize_signed {
 macro_rules! serialize_fmt {
     ($self:ident, $uxx:ident, $fmt:expr, $v:expr) => {{
         let mut s: String<$uxx> = String::new();
-        write!(&mut s, $fmt, $v).or(Err(Error::BufferFull))?;
+        write!(&mut s, $fmt, $v).unwrap();
         $self.buf.extend_from_slice(s.as_bytes())?;
         Ok(())
     }};
@@ -197,11 +197,11 @@ where
     }
 
     fn serialize_f32(self, v: f32) -> Result<Self::Ok> {
-        serialize_fmt!(self, U32, "{:e}", v)
+        serialize_fmt!(self, U16, "{:e}", v)
     }
 
     fn serialize_f64(self, v: f64) -> Result<Self::Ok> {
-        serialize_fmt!(self, U64, "{:e}", v)
+        serialize_fmt!(self, U32, "{:e}", v)
     }
 
     fn serialize_char(self, _v: char) -> Result<Self::Ok> {
@@ -524,14 +524,15 @@ mod tests {
         );
 
         assert_eq!(
-            &*crate::to_string::<N, _>(&Temperature { temperature: -20.345 }).unwrap(),
-            r#"{"temperature":-2.0345e1}"#
+            &*crate::to_string::<N, _>(&Temperature { temperature: -20345. }).unwrap(),
+            r#"{"temperature":-2.0345e4}"#
         );
 
         assert_eq!(
-            &*crate::to_string::<N, _>(&Temperature { temperature: -20.3456789e-30 }).unwrap(),
-            r#"{"temperature":-2.0345679e-29}"#
+            &*crate::to_string::<N, _>(&Temperature { temperature: -2.3456789012345e-23 }).unwrap(),
+            r#"{"temperature":-2.3456788e-23}"#
         );
+
     }
 
 


### PR DESCRIPTION
This uses `core::str::FromStr` and `core::fmt::LowerExp` traits.

Using those is probably not the fastest and most memory/text saving solution but it's hard to generally hit the perfect trade-off in terms of numerical accuracy, time/memory savings and code maintainability.

At some point I tried using `lexical-core` but that wasn't really no_std/embedded ready since it insists on messing with the build profiles and panic implementations.