### PR TITLE
Use std

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/confio/serde-json-wasm"
 version = "0.1.0"
 
 [dependencies]
-serde = {version = "^1.0.80", default-features = false }
+serde = {version = "^1.0.80", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 serde_derive = "^1.0.80"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,25 +1,18 @@
 [package]
-authors = ["Jorge Aparicio <jorge@japaric.io>"]
-categories = ["no-std"]
-description = "serde-json for no_std programs"
-documentation = "https://docs.rs/serde-json-core"
+authors = ["Jorge Aparicio <jorge@japaric.io>", "Ethan Frey <ethanfrey@noreply.github.com"]
+categories = ["wasm"]
+description = "serde-json for wasm programs"
+documentation = "https://docs.rs/serde-json-wasm"
 edition = "2018"
-keywords = ["serde", "json"]
+keywords = ["serde", "json", "wasm"]
 license = "MIT OR Apache-2.0"
-name = "serde-json-core"
+name = "serde-json-wasm"
 readme = "README.md"
-repository = "https://japaric.github.io/serde-json-core/serde_json_core"
-version = "0.0.1"
+repository = "https://github.com/confio/serde-json-wasm"
+version = "0.0.2"
 
 [dependencies]
-heapless = "0.4.0"
-
-[dependencies.serde]
-default-features = false
-version = "1.0.80"
+serde = {version = "^1.0.80", default-features = false }
 
 [dev-dependencies]
-serde_derive = "1.0.80"
-
-[features]
-std = ["serde/std"]
+serde_derive = "^1.0.80"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 name = "serde-json-wasm"
 readme = "README.md"
 repository = "https://github.com/confio/serde-json-wasm"
-version = "0.0.2"
+version = "0.1.0"
 
 [dependencies]
 serde = {version = "^1.0.80", default-features = false }

--- a/src/de/enum_.rs
+++ b/src/de/enum_.rs
@@ -2,10 +2,7 @@ use serde::de;
 
 use crate::de::{Deserializer, Error, Result};
 
-pub(crate) struct UnitVariantAccess<'a, 'b>
-where
-    'b: 'a,
-{
+pub(crate) struct UnitVariantAccess<'a, 'b>  {
     de: &'a mut Deserializer<'b>,
 }
 

--- a/src/de/enum_.rs
+++ b/src/de/enum_.rs
@@ -2,7 +2,7 @@ use serde::de;
 
 use crate::de::{Deserializer, Error, Result};
 
-pub(crate) struct UnitVariantAccess<'a, 'b>  {
+pub(crate) struct UnitVariantAccess<'a, 'b> {
     de: &'a mut Deserializer<'b>,
 }
 

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -2,7 +2,7 @@ use serde::de::{self, Visitor};
 
 use crate::de::{Deserializer, Error};
 
-pub struct MapAccess<'a, 'b>  {
+pub struct MapAccess<'a, 'b> {
     de: &'a mut Deserializer<'b>,
     first: bool,
 }
@@ -57,7 +57,7 @@ impl<'a, 'de> de::MapAccess<'de> for MapAccess<'a, 'de> {
     }
 }
 
-struct MapKey<'a, 'b>  {
+struct MapKey<'a, 'b> {
     de: &'a mut Deserializer<'b>,
 }
 

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -2,10 +2,7 @@ use serde::de::{self, Visitor};
 
 use crate::de::{Deserializer, Error};
 
-pub struct MapAccess<'a, 'b>
-where
-    'b: 'a,
-{
+pub struct MapAccess<'a, 'b>  {
     de: &'a mut Deserializer<'b>,
     first: bool,
 }
@@ -60,10 +57,7 @@ impl<'a, 'de> de::MapAccess<'de> for MapAccess<'a, 'de> {
     }
 }
 
-struct MapKey<'a, 'b>
-where
-    'b: 'a,
-{
+struct MapKey<'a, 'b>  {
     de: &'a mut Deserializer<'b>,
 }
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,6 +1,6 @@
 //! Deserialize JSON data to a Rust data structure
 
-use std::{fmt, error, str::from_utf8};
+use std::{error, fmt, str::from_utf8};
 
 use serde::de::{self, Visitor};
 
@@ -118,7 +118,6 @@ impl fmt::Display for Error {
         )
     }
 }
-
 
 pub(crate) struct Deserializer<'b> {
     slice: &'b [u8],
@@ -603,7 +602,6 @@ impl de::Error for Error {
         unreachable!()
     }
 }
-
 
 /// Deserializes an instance of type `T` from bytes of JSON text
 pub fn from_slice<'a, T>(v: &'a [u8]) -> Result<T>

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -605,7 +605,10 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         V: Visitor<'de>,
     {
         match self.parse_whitespace().ok_or(Error::EofWhileParsingValue)? {
+            // if it is a string enum
             b'"' => visitor.visit_enum(UnitVariantAccess::new(self)),
+            // if it is a struct enum
+            b'{' => Err(Error::Custom("TODO: parse enum struct".to_string())),
             _ => Err(Error::ExpectedSomeValue),
         }
     }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,6 +1,6 @@
 //! Deserialize JSON data to a Rust data structure
 
-use std::{fmt, error};
+use std::{fmt, error, str::from_utf8};
 
 use serde::de::{self, Visitor};
 
@@ -212,7 +212,7 @@ impl<'a> Deserializer<'a> {
                 Some(b'"') => {
                     let end = self.index;
                     self.eat_char();
-                    return str::from_utf8(&self.slice[start..end])
+                    return from_utf8(&self.slice[start..end])
                         .map_err(|_| Error::InvalidUnicodeCodePoint);
                 }
                 Some(_) => self.eat_char(),

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,6 +1,6 @@
 //! Deserialize JSON data to a Rust data structure
 
-use core::{fmt, str};
+use std::{fmt, error};
 
 use serde::de::{self, Visitor};
 
@@ -67,12 +67,58 @@ pub enum Error {
     __Extensible,
 }
 
-#[cfg(feature = "std")]
-impl ::std::error::Error for Error {
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        None
+    }
+
     fn description(&self) -> &str {
-        ""
+        "(use display)"
     }
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Error::EofWhileParsingList => "EOF while parsing a list.",
+                Error::EofWhileParsingObject => "EOF while parsing an object.",
+                Error::EofWhileParsingString => "EOF while parsing a string.",
+                Error::EofWhileParsingValue => "EOF while parsing a JSON value.",
+                Error::ExpectedColon => "Expected this character to be a `':'`.",
+                Error::ExpectedListCommaOrEnd => {
+                    "Expected this character to be either a `','` or\
+                     a \
+                     `']'`."
+                }
+                Error::ExpectedObjectCommaOrEnd => {
+                    "Expected this character to be either a `','` \
+                     or a \
+                     `'}'`."
+                }
+                Error::ExpectedSomeIdent => {
+                    "Expected to parse either a `true`, `false`, or a \
+                     `null`."
+                }
+                Error::ExpectedSomeValue => "Expected this character to start a JSON value.",
+                Error::InvalidNumber => "Invalid number.",
+                Error::InvalidType => "Invalid type",
+                Error::InvalidUnicodeCodePoint => "Invalid unicode code point.",
+                Error::KeyMustBeAString => "Object key is not a string.",
+                Error::TrailingCharacters => {
+                    "JSON has non-whitespace trailing characters after \
+                     the \
+                     value."
+                }
+                Error::TrailingComma => "JSON has a comma after the last value in an array or map.",
+                _ => "Invalid JSON",
+            }
+        )
+    }
+}
+
 
 pub(crate) struct Deserializer<'b> {
     slice: &'b [u8],
@@ -558,47 +604,6 @@ impl de::Error for Error {
     }
 }
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Error::EofWhileParsingList => "EOF while parsing a list.",
-                Error::EofWhileParsingObject => "EOF while parsing an object.",
-                Error::EofWhileParsingString => "EOF while parsing a string.",
-                Error::EofWhileParsingValue => "EOF while parsing a JSON value.",
-                Error::ExpectedColon => "Expected this character to be a `':'`.",
-                Error::ExpectedListCommaOrEnd => {
-                    "Expected this character to be either a `','` or\
-                     a \
-                     `']'`."
-                }
-                Error::ExpectedObjectCommaOrEnd => {
-                    "Expected this character to be either a `','` \
-                     or a \
-                     `'}'`."
-                }
-                Error::ExpectedSomeIdent => {
-                    "Expected to parse either a `true`, `false`, or a \
-                     `null`."
-                }
-                Error::ExpectedSomeValue => "Expected this character to start a JSON value.",
-                Error::InvalidNumber => "Invalid number.",
-                Error::InvalidType => "Invalid type",
-                Error::InvalidUnicodeCodePoint => "Invalid unicode code point.",
-                Error::KeyMustBeAString => "Object key is not a string.",
-                Error::TrailingCharacters => {
-                    "JSON has non-whitespace trailing characters after \
-                     the \
-                     value."
-                }
-                Error::TrailingComma => "JSON has a comma after the last value in an array or map.",
-                _ => "Invalid JSON",
-            }
-        )
-    }
-}
 
 /// Deserializes an instance of type `T` from bytes of JSON text
 pub fn from_slice<'a, T>(v: &'a [u8]) -> Result<T>

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -63,6 +63,9 @@ pub enum Error {
     /// JSON has a comma after the last value in an array or map.
     TrailingComma,
 
+    /// Custom error message from serde
+    Custom(String),
+
     #[doc(hidden)]
     __Extensible,
 }
@@ -74,6 +77,15 @@ impl error::Error for Error {
 
     fn description(&self) -> &str {
         "(use display)"
+    }
+}
+
+impl de::Error for Error {
+    fn custom<T>(msg: T) -> Self
+        where
+            T: fmt::Display,
+    {
+        Error::Custom(msg.to_string())
     }
 }
 
@@ -113,6 +125,7 @@ impl fmt::Display for Error {
                      value."
                 }
                 Error::TrailingComma => "JSON has a comma after the last value in an array or map.",
+                Error::Custom(msg) => &msg,
                 _ => "Invalid JSON",
             }
         )
@@ -599,16 +612,6 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        unreachable!()
-    }
-}
-
-impl de::Error for Error {
-    fn custom<T>(_msg: T) -> Self
-    where
-        T: fmt::Display,
-    {
-        // TODO
         unreachable!()
     }
 }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -529,7 +529,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        match self.peek().ok_or(Error::EofWhileParsingValue)? {
+        match self.parse_whitespace().ok_or(Error::EofWhileParsingValue)? {
             b'[' => {
                 self.eat_char();
                 let ret = visitor.visit_seq(SeqAccess::new(self))?;
@@ -866,6 +866,97 @@ mod tests {
         );
     }
 
+    #[test]
+    fn deserialize_optional_vector() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        pub struct Response {
+            pub log: Option<String>,
+            pub messages: Vec<Msg>,
+        }
+
+        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(serde_derive::Serialize)]
+        pub struct Msg {
+            pub name: String,
+        }
+
+        #[derive(Debug, Deserialize, PartialEq)]
+        pub struct OptIn {
+            pub name: Option<String>,
+        }
+
+        let m: Msg = crate::from_str(r#"{
+          "name": "one"
+        }"#).expect("simple");
+        assert_eq!(m, Msg{name: "one".to_string()});
+
+        let o: OptIn = crate::from_str(r#"{
+          "name": "two"
+        }"#).expect("opt");
+        assert_eq!(o, OptIn{name: Some("two".to_string())});
+
+        let res: Response = crate::from_str(r#"{
+          "log": "my log",
+          "messages": [{"name": "one"}]
+        }"#).expect("fud");
+        assert_eq!(res, Response{
+            log: Some("my log".to_string()),
+            messages: vec![Msg{name: "one".to_string()}],
+        });
+
+        let res: Response = crate::from_str(r#"{"log": null,"messages": []}"#).expect("fud");
+        assert_eq!(res, Response{log: None, messages: Vec::new()});
+    }
+
+
+    #[test]
+    fn deserialize_embedded_enum() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        #[serde(rename_all = "lowercase")]
+        pub enum MyResult {
+            Ok(Response),
+            Err(String),
+        }
+
+        #[derive(Debug, Deserialize, PartialEq)]
+        pub struct Response {
+            pub log: Option<String>,
+            pub messages: Vec<Msg>,
+        }
+
+        #[derive(Debug, Deserialize, PartialEq)]
+        pub struct Msg {
+            pub name: String,
+            pub amount: Option<String>,
+        }
+
+        let res: MyResult = crate::from_str(r#"{
+          "ok": {
+            "messages": [{
+                "name": "fred",
+                "amount": "15"
+            }],
+          }
+        }"#).expect("goo");
+        assert_eq!(res, MyResult::Ok(Response{log: Some("hello".to_string()), messages: vec![Msg{name: "fred".to_string(), amount: Some("15".to_string())}]}));
+
+        let res: MyResult= crate::from_str(r#"{
+          "ok": {
+            "log": "hello",
+            "messages": [],
+          }
+        }"#).expect("goo");
+        assert_eq!(res, MyResult::Ok(Response{log: Some("hello".to_string()), messages: Vec::new()}));
+
+        let res: MyResult = crate::from_str(r#"{
+          "ok": {
+            "log": null,
+            "messages": [],
+          }
+        }"#).expect("goo");
+        assert_eq!(res, MyResult::Ok(Response{log: None, messages: Vec::new()}));
+    }
+
     // See https://iot.mozilla.org/wot/#thing-resource
     #[test]
     fn wot() {
@@ -895,7 +986,7 @@ mod tests {
             #[serde(borrow)]
             description: Option<&'a str>,
             href: &'a str,
-            owned: String,
+            owned: Option<String>,
         }
 
         assert_eq!(
@@ -915,10 +1006,11 @@ mod tests {
       "type": "number",
       "unit": "percent",
       "href": "/properties/humidity",
-      "owned": "own humidity"
+      "owned": null
     },
     "led": {
       "type": "boolean",
+      "unit": null,
       "description": "A red LED",
       "href": "/properties/led",
       "owned": "own led"
@@ -934,21 +1026,21 @@ mod tests {
                         unit: Some("celsius"),
                         description: Some("An ambient temperature sensor"),
                         href: "/properties/temperature",
-                        owned: "own temperature".to_string(),
+                        owned: Some("own temperature".to_string()),
                     },
                     humidity: Property {
                         ty: Type::Number,
                         unit: Some("percent"),
                         description: None,
                         href: "/properties/humidity",
-                        owned: "own humidity".to_string(),
+                        owned: None,
                     },
                     led: Property {
                         ty: Type::Boolean,
                         unit: None,
                         description: Some("A red LED"),
                         href: "/properties/led",
-                        owned: "own led".to_string(),
+                        owned: Some("own led".to_string()),
                     },
                 },
                 ty: Type::Thing,

--- a/src/de/seq.rs
+++ b/src/de/seq.rs
@@ -2,10 +2,7 @@ use serde::de;
 
 use crate::de::{Deserializer, Error, Result};
 
-pub(crate) struct SeqAccess<'a, 'b>
-where
-    'b: 'a,
-{
+pub(crate) struct SeqAccess<'a, 'b>  {
     first: bool,
     de: &'a mut Deserializer<'b>,
 }

--- a/src/de/seq.rs
+++ b/src/de/seq.rs
@@ -2,7 +2,7 @@ use serde::de;
 
 use crate::de::{Deserializer, Error, Result};
 
-pub(crate) struct SeqAccess<'a, 'b>  {
+pub(crate) struct SeqAccess<'a, 'b> {
     first: bool,
     de: &'a mut Deserializer<'b>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! [`serde-json`] for `no_std` programs
+//! [`serde-json`] for `wasm` programs
 //!
 //! [`serde-json`]: https://crates.io/crates/serde_json
 //!
@@ -57,7 +57,6 @@
 #![deny(rust_2018_compatibility)]
 #![deny(rust_2018_idioms)]
 #![deny(warnings)]
-#![no_std]
 
 pub mod de;
 pub mod ser;

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -1,10 +1,10 @@
 //! Serialize a Rust data structure into JSON data
 
-use core::{fmt, mem};
+use std::{fmt, error};
 
 use serde::ser;
 
-use heapless::{String, Vec};
+use std::vec::Vec;
 
 use self::seq::SerializeSeq;
 use self::struct_::SerializeStruct;
@@ -36,10 +36,14 @@ impl From<u8> for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl ::std::error::Error for Error {
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        None
+    }
+
     fn description(&self) -> &str {
-        ""
+        "(use display)"
     }
 }
 
@@ -49,17 +53,12 @@ impl fmt::Display for Error {
     }
 }
 
-pub(crate) struct Serializer<B>
-where
-    B: heapless::ArrayLength<u8>,
+pub(crate) struct Serializer
 {
-    buf: Vec<u8, B>,
+    buf: Vec<u8>,
 }
 
-impl<B> Serializer<B>
-where
-    B: heapless::ArrayLength<u8>,
-{
+impl Serializer {
     fn new() -> Self {
         Serializer { buf: Vec::new() }
     }
@@ -123,18 +122,15 @@ macro_rules! serialize_signed {
     }};
 }
 
-impl<'a, B> ser::Serializer for &'a mut Serializer<B>
-where
-    B: heapless::ArrayLength<u8>,
-{
+impl<'a> ser::Serializer for &'a mut Serializer {
     type Ok = ();
     type Error = Error;
-    type SerializeSeq = SerializeSeq<'a, B>;
-    type SerializeTuple = SerializeSeq<'a, B>;
+    type SerializeSeq = SerializeSeq<'a>;
+    type SerializeTuple = SerializeSeq<'a>;
     type SerializeTupleStruct = Unreachable;
     type SerializeTupleVariant = Unreachable;
     type SerializeMap = Unreachable;
-    type SerializeStruct = SerializeStruct<'a, B>;
+    type SerializeStruct = SerializeStruct<'a>;
     type SerializeStructVariant = Unreachable;
 
     fn serialize_bool(self, v: bool) -> Result<Self::Ok> {
@@ -320,9 +316,8 @@ where
 }
 
 /// Serializes the given data structure as a string of JSON text
-pub fn to_string<B, T>(value: &T) -> Result<String<B>>
+pub fn to_string<T>(value: &T) -> Result<String>
 where
-    B: heapless::ArrayLength<u8>,
     T: ser::Serialize + ?Sized,
 {
     let mut ser = Serializer::new();
@@ -331,9 +326,8 @@ where
 }
 
 /// Serializes the given data structure as a JSON byte vector
-pub fn to_vec<B, T>(value: &T) -> Result<Vec<u8, B>>
+pub fn to_vec<T>(value: &T) -> Result<Vec<u8>>
 where
-    B: heapless::ArrayLength<u8>,
     T: ser::Serialize + ?Sized,
 {
     let mut ser = Serializer::new();
@@ -421,18 +415,14 @@ impl ser::SerializeStructVariant for Unreachable {
 mod tests {
     use serde_derive::Serialize;
 
-    use heapless::consts::U128;
-
-    type N = U128;
-
     #[test]
     fn array() {
-        assert_eq!(&*crate::to_string::<N, _>(&[0, 1, 2]).unwrap(), "[0,1,2]");
+        assert_eq!(&*crate::to_string(&[0, 1, 2]).unwrap(), "[0,1,2]");
     }
 
     #[test]
     fn bool() {
-        assert_eq!(&*crate::to_string::<N, _>(&true).unwrap(), "true");
+        assert_eq!(&*crate::to_string(&true).unwrap(), "true");
     }
 
     #[test]
@@ -446,19 +436,19 @@ mod tests {
         }
 
         assert_eq!(
-            &*crate::to_string::<N, _>(&Type::Boolean).unwrap(),
+            &*crate::to_string(&Type::Boolean).unwrap(),
             r#""boolean""#
         );
 
         assert_eq!(
-            &*crate::to_string::<N, _>(&Type::Number).unwrap(),
+            &*crate::to_string(&Type::Number).unwrap(),
             r#""number""#
         );
     }
 
     #[test]
     fn str() {
-        assert_eq!(&*crate::to_string::<N, _>("hello").unwrap(), r#""hello""#);
+        assert_eq!(&*crate::to_string("hello").unwrap(), r#""hello""#);
     }
 
     #[test]
@@ -469,7 +459,7 @@ mod tests {
         }
 
         assert_eq!(
-            &*crate::to_string::<N, _>(&Led { led: true }).unwrap(),
+            &*crate::to_string(&Led { led: true }).unwrap(),
             r#"{"led":true}"#
         );
     }
@@ -482,22 +472,22 @@ mod tests {
         }
 
         assert_eq!(
-            &*crate::to_string::<N, _>(&Temperature { temperature: 127 }).unwrap(),
+            &*crate::to_string(&Temperature { temperature: 127 }).unwrap(),
             r#"{"temperature":127}"#
         );
 
         assert_eq!(
-            &*crate::to_string::<N, _>(&Temperature { temperature: 20 }).unwrap(),
+            &*crate::to_string(&Temperature { temperature: 20 }).unwrap(),
             r#"{"temperature":20}"#
         );
 
         assert_eq!(
-            &*crate::to_string::<N, _>(&Temperature { temperature: -17 }).unwrap(),
+            &*crate::to_string(&Temperature { temperature: -17 }).unwrap(),
             r#"{"temperature":-17}"#
         );
 
         assert_eq!(
-            &*crate::to_string::<N, _>(&Temperature { temperature: -128 }).unwrap(),
+            &*crate::to_string(&Temperature { temperature: -128 }).unwrap(),
             r#"{"temperature":-128}"#
         );
     }
@@ -510,7 +500,7 @@ mod tests {
         }
 
         assert_eq!(
-            crate::to_string::<N, _>(&Property {
+            crate::to_string(&Property {
                 description: Some("An ambient temperature sensor"),
             })
             .unwrap(),
@@ -519,7 +509,7 @@ mod tests {
 
         // XXX Ideally this should produce "{}"
         assert_eq!(
-            crate::to_string::<N, _>(&Property { description: None }).unwrap(),
+            crate::to_string(&Property { description: None }).unwrap(),
             r#"{"description":null}"#
         );
     }
@@ -532,7 +522,7 @@ mod tests {
         }
 
         assert_eq!(
-            &*crate::to_string::<N, _>(&Temperature { temperature: 20 }).unwrap(),
+            &*crate::to_string(&Temperature { temperature: 20 }).unwrap(),
             r#"{"temperature":20}"#
         );
     }
@@ -542,7 +532,7 @@ mod tests {
         #[derive(Serialize)]
         struct Empty {}
 
-        assert_eq!(&*crate::to_string::<N, _>(&Empty {}).unwrap(), r#"{}"#);
+        assert_eq!(&*crate::to_string(&Empty {}).unwrap(), r#"{}"#);
 
         #[derive(Serialize)]
         struct Tuple {
@@ -551,7 +541,7 @@ mod tests {
         }
 
         assert_eq!(
-            &*crate::to_string::<N, _>(&Tuple { a: true, b: false }).unwrap(),
+            &*crate::to_string(&Tuple { a: true, b: false }).unwrap(),
             r#"{"a":true,"b":false}"#
         );
     }

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -1,6 +1,6 @@
 //! Serialize a Rust data structure into JSON data
 
-use std::{fmt, error};
+use std::{error, fmt};
 
 use serde::ser;
 
@@ -36,7 +36,6 @@ impl From<u8> for Error {
     }
 }
 
-
 impl error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         None
@@ -53,8 +52,7 @@ impl fmt::Display for Error {
     }
 }
 
-pub(crate) struct Serializer
-{
+pub(crate) struct Serializer {
     buf: Vec<u8>,
 }
 
@@ -434,15 +432,9 @@ mod tests {
             Number,
         }
 
-        assert_eq!(
-            &*crate::to_string(&Type::Boolean).unwrap(),
-            r#""boolean""#
-        );
+        assert_eq!(&*crate::to_string(&Type::Boolean).unwrap(), r#""boolean""#);
 
-        assert_eq!(
-            &*crate::to_string(&Type::Number).unwrap(),
-            r#""number""#
-        );
+        assert_eq!(&*crate::to_string(&Type::Number).unwrap(), r#""number""#);
     }
 
     #[test]

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -68,7 +68,7 @@ impl Serializer {
 // which take 200+ bytes of ROM / Flash
 macro_rules! serialize_unsigned {
     ($self:ident, $N:expr, $v:expr) => {{
-        let mut buf: [u8; $N] = unsafe { mem::uninitialized() };
+        let mut buf = [0u8; $N];
 
         let mut v = $v;
         let mut i = $N - 1;
@@ -83,7 +83,7 @@ macro_rules! serialize_unsigned {
             }
         }
 
-        $self.buf.extend_from_slice(&buf[i..])?;
+        $self.buf.extend_from_slice(&buf[i..]);
         Ok(())
     }};
 }
@@ -99,7 +99,7 @@ macro_rules! serialize_signed {
             (false, v as $uxx)
         };
 
-        let mut buf: [u8; $N] = unsafe { mem::uninitialized() };
+        let mut buf = [0u8; $N];
         let mut i = $N - 1;
         loop {
             buf[i] = (v % 10) as u8 + b'0';
@@ -117,7 +117,7 @@ macro_rules! serialize_signed {
         } else {
             i += 1;
         }
-        $self.buf.extend_from_slice(&buf[i..])?;
+        $self.buf.extend_from_slice(&buf[i..]);
         Ok(())
     }};
 }
@@ -135,11 +135,10 @@ impl<'a> ser::Serializer for &'a mut Serializer {
 
     fn serialize_bool(self, v: bool) -> Result<Self::Ok> {
         if v {
-            self.buf.extend_from_slice(b"true")?;
+            self.buf.extend_from_slice(b"true");
         } else {
-            self.buf.extend_from_slice(b"false")?;
+            self.buf.extend_from_slice(b"false");
         }
-
         Ok(())
     }
 
@@ -196,9 +195,9 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_str(self, v: &str) -> Result<Self::Ok> {
-        self.buf.push(b'"')?;
-        self.buf.extend_from_slice(v.as_bytes())?;
-        self.buf.push(b'"')?;
+        self.buf.push(b'"');
+        self.buf.extend_from_slice(v.as_bytes());
+        self.buf.push(b'"');
         Ok(())
     }
 
@@ -207,7 +206,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_none(self) -> Result<Self::Ok> {
-        self.buf.extend_from_slice(b"null")?;
+        self.buf.extend_from_slice(b"null");
         Ok(())
     }
 
@@ -260,7 +259,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
-        self.buf.push(b'[')?;
+        self.buf.push(b'[');
 
         Ok(SerializeSeq::new(self))
     }
@@ -292,7 +291,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
-        self.buf.push(b'{')?;
+        self.buf.push(b'{');
 
         Ok(SerializeStruct::new(self))
     }

--- a/src/ser/seq.rs
+++ b/src/ser/seq.rs
@@ -2,7 +2,7 @@ use serde::ser;
 
 use crate::ser::{Error, Result, Serializer};
 
-pub struct SerializeSeq<'a>  {
+pub struct SerializeSeq<'a> {
     de: &'a mut Serializer,
     first: bool,
 }
@@ -13,7 +13,7 @@ impl<'a> SerializeSeq<'a> {
     }
 }
 
-impl<'a> ser::SerializeSeq for SerializeSeq<'a>  {
+impl<'a> ser::SerializeSeq for SerializeSeq<'a> {
     type Ok = ();
     type Error = Error;
 
@@ -36,7 +36,7 @@ impl<'a> ser::SerializeSeq for SerializeSeq<'a>  {
     }
 }
 
-impl<'a> ser::SerializeTuple for SerializeSeq<'a>  {
+impl<'a> ser::SerializeTuple for SerializeSeq<'a> {
     type Ok = ();
     type Error = Error;
 

--- a/src/ser/seq.rs
+++ b/src/ser/seq.rs
@@ -1,7 +1,5 @@
 use serde::ser;
 
-use heapless::ArrayLength;
-
 use crate::ser::{Error, Result, Serializer};
 
 pub struct SerializeSeq<'a>  {
@@ -24,7 +22,7 @@ impl<'a> ser::SerializeSeq for SerializeSeq<'a>  {
         T: ser::Serialize,
     {
         if !self.first {
-            self.de.buf.push(b',')?;
+            self.de.buf.push(b',');
         }
         self.first = false;
 
@@ -33,7 +31,7 @@ impl<'a> ser::SerializeSeq for SerializeSeq<'a>  {
     }
 
     fn end(self) -> Result<Self::Ok> {
-        self.de.buf.push(b']')?;
+        self.de.buf.push(b']');
         Ok(())
     }
 }

--- a/src/ser/seq.rs
+++ b/src/ser/seq.rs
@@ -4,27 +4,18 @@ use heapless::ArrayLength;
 
 use crate::ser::{Error, Result, Serializer};
 
-pub struct SerializeSeq<'a, B>
-where
-    B: ArrayLength<u8>,
-{
-    de: &'a mut Serializer<B>,
+pub struct SerializeSeq<'a>  {
+    de: &'a mut Serializer,
     first: bool,
 }
 
-impl<'a, B> SerializeSeq<'a, B>
-where
-    B: ArrayLength<u8>,
-{
-    pub(crate) fn new(de: &'a mut Serializer<B>) -> Self {
+impl<'a> SerializeSeq<'a> {
+    pub(crate) fn new(de: &'a mut Serializer) -> Self {
         SerializeSeq { de, first: true }
     }
 }
 
-impl<'a, B> ser::SerializeSeq for SerializeSeq<'a, B>
-where
-    B: ArrayLength<u8>,
-{
+impl<'a> ser::SerializeSeq for SerializeSeq<'a>  {
     type Ok = ();
     type Error = Error;
 
@@ -47,10 +38,7 @@ where
     }
 }
 
-impl<'a, B> ser::SerializeTuple for SerializeSeq<'a, B>
-where
-    B: ArrayLength<u8>,
-{
+impl<'a> ser::SerializeTuple for SerializeSeq<'a>  {
     type Ok = ();
     type Error = Error;
 

--- a/src/ser/struct_.rs
+++ b/src/ser/struct_.rs
@@ -23,13 +23,13 @@ impl<'a> ser::SerializeStruct for SerializeStruct<'a> {
     {
         // XXX if `value` is `None` we not produce any output for this field
         if !self.first {
-            self.de.buf.push(b',')?;
+            self.de.buf.push(b',');
         }
         self.first = false;
 
-        self.de.buf.push(b'"')?;
-        self.de.buf.extend_from_slice(key.as_bytes())?;
-        self.de.buf.extend_from_slice(b"\":")?;
+        self.de.buf.push(b'"');
+        self.de.buf.extend_from_slice(key.as_bytes());
+        self.de.buf.extend_from_slice(b"\":");
 
         value.serialize(&mut *self.de)?;
 
@@ -37,7 +37,7 @@ impl<'a> ser::SerializeStruct for SerializeStruct<'a> {
     }
 
     fn end(self) -> Result<Self::Ok> {
-        self.de.buf.push(b'}')?;
+        self.de.buf.push(b'}');
         Ok(())
     }
 }

--- a/src/ser/struct_.rs
+++ b/src/ser/struct_.rs
@@ -7,7 +7,7 @@ pub struct SerializeStruct<'a> {
     first: bool,
 }
 
-impl<'a> SerializeStruct<'a>  {
+impl<'a> SerializeStruct<'a> {
     pub(crate) fn new(de: &'a mut Serializer) -> Self {
         SerializeStruct { de, first: true }
     }

--- a/src/ser/struct_.rs
+++ b/src/ser/struct_.rs
@@ -1,30 +1,19 @@
 use serde::ser;
 
-use heapless::ArrayLength;
-
 use crate::ser::{Error, Result, Serializer};
 
-pub struct SerializeStruct<'a, B>
-where
-    B: ArrayLength<u8>,
-{
-    de: &'a mut Serializer<B>,
+pub struct SerializeStruct<'a> {
+    de: &'a mut Serializer,
     first: bool,
 }
 
-impl<'a, B> SerializeStruct<'a, B>
-where
-    B: ArrayLength<u8>,
-{
-    pub(crate) fn new(de: &'a mut Serializer<B>) -> Self {
+impl<'a> SerializeStruct<'a>  {
+    pub(crate) fn new(de: &'a mut Serializer) -> Self {
         SerializeStruct { de, first: true }
     }
 }
 
-impl<'a, B> ser::SerializeStruct for SerializeStruct<'a, B>
-where
-    B: ArrayLength<u8>,
-{
+impl<'a> ser::SerializeStruct for SerializeStruct<'a> {
     type Ok = ();
     type Error = Error;
 


### PR DESCRIPTION
No longer `no_std`. Designed rather to work with wasm - small code size and no floating point are the main goals.

* Works with the standard lib, handles integer types, &str but also String and Vec now.
* Error types also implement std::error::Error

One open bug that it doesn't parse enum structs - only enum string variants.
That will be another PR