### PR TITLE
Parse enum structs

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,25 +1,18 @@
 [package]
-authors = ["Jorge Aparicio <jorge@japaric.io>"]
-categories = ["no-std"]
-description = "serde-json for no_std programs"
-documentation = "https://docs.rs/serde-json-core"
+authors = ["Jorge Aparicio <jorge@japaric.io>", "Ethan Frey <ethanfrey@noreply.github.com"]
+categories = ["wasm"]
+description = "serde-json for wasm programs"
+documentation = "https://docs.rs/serde-json-wasm"
 edition = "2018"
-keywords = ["serde", "json"]
+keywords = ["serde", "json", "wasm"]
 license = "MIT OR Apache-2.0"
-name = "serde-json-core"
+name = "serde-json-wasm"
 readme = "README.md"
-repository = "https://japaric.github.io/serde-json-core/serde_json_core"
-version = "0.0.1"
+repository = "https://github.com/confio/serde-json-wasm"
+version = "0.1.0"
 
 [dependencies]
-heapless = "0.4.0"
-
-[dependencies.serde]
-default-features = false
-version = "1.0.80"
+serde = {version = "^1.0.80", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-serde_derive = "1.0.80"
-
-[features]
-std = ["serde/std"]
+serde_derive = "^1.0.80"

--- a/src/de/enum_.rs
+++ b/src/de/enum_.rs
@@ -2,10 +2,7 @@ use serde::de;
 
 use crate::de::{Deserializer, Error, Result};
 
-pub(crate) struct UnitVariantAccess<'a, 'b>
-where
-    'b: 'a,
-{
+pub(crate) struct UnitVariantAccess<'a, 'b> {
     de: &'a mut Deserializer<'b>,
 }
 

--- a/src/de/enum_.rs
+++ b/src/de/enum_.rs
@@ -53,3 +53,59 @@ impl<'de, 'a> de::VariantAccess<'de> for UnitVariantAccess<'a, 'de> {
         Err(Error::InvalidType)
     }
 }
+
+pub(crate) struct VariantAccess<'a, 'b> {
+    de: &'a mut Deserializer<'b>,
+}
+
+impl<'a, 'b> VariantAccess<'a, 'b> {
+    pub fn new(de: &'a mut Deserializer<'b>) -> Self {
+        VariantAccess { de: de }
+    }
+}
+
+impl<'a, 'de> de::EnumAccess<'de> for VariantAccess<'a, 'de> {
+    type Error = Error;
+    type Variant = Self;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self)>
+        where
+            V: de::DeserializeSeed<'de>,
+    {
+        let val = seed.deserialize(&mut *self.de)?;
+        self.de.parse_object_colon()?;
+        Ok((val, self))
+    }
+}
+
+impl<'a, 'de> de::VariantAccess<'de> for VariantAccess<'a, 'de> {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<()> {
+//        Err(Error::Custom("unit_variant".to_string()))
+        unreachable!();
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value>
+        where
+            T: de::DeserializeSeed<'de>,
+    {
+        seed.deserialize(self.de)
+    }
+
+    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value>
+        where
+            V: de::Visitor<'de>,
+    {
+//        Err(Error::Custom("tuple_variant".to_string()))
+        unreachable!();
+    }
+
+    fn struct_variant<V>(self, _fields: &'static [&'static str], _visitor: V) -> Result<V::Value>
+        where
+            V: de::Visitor<'de>,
+    {
+//        Err(Error::Custom("TODO: implement struct_variant".to_string()))
+        unreachable!();
+    }
+}

--- a/src/de/enum_.rs
+++ b/src/de/enum_.rs
@@ -69,8 +69,8 @@ impl<'a, 'de> de::EnumAccess<'de> for StructVariantAccess<'a, 'de> {
     type Variant = Self;
 
     fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self)>
-        where
-            V: de::DeserializeSeed<'de>,
+    where
+        V: de::DeserializeSeed<'de>,
     {
         let val = seed.deserialize(&mut *self.de)?;
         self.de.parse_object_colon()?;
@@ -86,30 +86,34 @@ impl<'a, 'de> de::VariantAccess<'de> for StructVariantAccess<'a, 'de> {
     }
 
     fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value>
-        where
-            T: de::DeserializeSeed<'de>,
+    where
+        T: de::DeserializeSeed<'de>,
     {
         let value = seed.deserialize(&mut *self.de)?;
         // we remove trailing '}' to be consistent with struct_variant algorithm
-        match self.de.parse_whitespace().ok_or(Error::EofWhileParsingValue)? {
+        match self
+            .de
+            .parse_whitespace()
+            .ok_or(Error::EofWhileParsingValue)?
+        {
             b'}' => {
                 self.de.eat_char();
                 Ok(value)
-            },
+            }
             _ => Err(Error::ExpectedSomeValue),
         }
     }
 
     fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value>
-        where
-            V: de::Visitor<'de>,
+    where
+        V: de::Visitor<'de>,
     {
         Err(Error::InvalidType)
     }
 
     fn struct_variant<V>(self, fields: &'static [&'static str], visitor: V) -> Result<V::Value>
-        where
-            V: de::Visitor<'de>,
+    where
+        V: de::Visitor<'de>,
     {
         de::Deserializer::deserialize_struct(self.de, "", fields, visitor)
     }

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -2,10 +2,7 @@ use serde::de::{self, Visitor};
 
 use crate::de::{Deserializer, Error};
 
-pub struct MapAccess<'a, 'b>
-where
-    'b: 'a,
-{
+pub struct MapAccess<'a, 'b> {
     de: &'a mut Deserializer<'b>,
     first: bool,
 }
@@ -60,10 +57,7 @@ impl<'a, 'de> de::MapAccess<'de> for MapAccess<'a, 'de> {
     }
 }
 
-struct MapKey<'a, 'b>
-where
-    'b: 'a,
-{
+struct MapKey<'a, 'b> {
     de: &'a mut Deserializer<'b>,
 }
 
@@ -289,10 +283,12 @@ impl<'de, 'a> de::Deserializer<'de> for MapKey<'a, 'de> {
         self.deserialize_str(visitor)
     }
 
-    fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        unreachable!()
+        // Even if we’re ignoring the contents of the map, we still need to
+        // deserialize the string here in order to chomp the key’s characters.
+        self.deserialize_str(visitor)
     }
 }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -82,8 +82,8 @@ impl error::Error for Error {
 
 impl de::Error for Error {
     fn custom<T>(msg: T) -> Self
-        where
-            T: fmt::Display,
+    where
+        T: fmt::Display,
     {
         Error::Custom(msg.to_string())
     }
@@ -611,7 +611,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             b'{' => {
                 self.eat_char();
                 visitor.visit_enum(StructVariantAccess::new(self))
-            },
+            }
             _ => Err(Error::ExpectedSomeIdent),
         }
     }
@@ -816,10 +816,13 @@ mod tests {
 
         // wrong number of args
         match crate::from_str::<Xy>(r#"[10]"#) {
-            Err(super::Error::Custom(_)) => {},
+            Err(super::Error::Custom(_)) => {}
             _ => panic!("expect custom error"),
         }
-        assert_eq!(crate::from_str::<Xy>(r#"[10, 20, 30]"#), Err(crate::de::Error::TrailingCharacters));
+        assert_eq!(
+            crate::from_str::<Xy>(r#"[10, 20, 30]"#),
+            Err(crate::de::Error::TrailingCharacters)
+        );
     }
 
     #[test]
@@ -847,7 +850,9 @@ mod tests {
         );
 
         assert_eq!(
-            crate::from_str(r#"{ "temperature": 20, "source": { "station": "dock", "sensors": ["front", "back"] } }"#),
+            crate::from_str(
+                r#"{ "temperature": 20, "source": { "station": "dock", "sensors": ["front", "back"] } }"#
+            ),
             Ok(Temperature { temperature: 20 })
         );
 
@@ -880,8 +885,7 @@ mod tests {
             pub messages: Vec<Msg>,
         }
 
-        #[derive(Debug, Deserialize, PartialEq)]
-        #[derive(serde_derive::Serialize)]
+        #[derive(Debug, Deserialize, PartialEq, serde_derive::Serialize)]
         pub struct Msg {
             pub name: String,
         }
@@ -891,29 +895,58 @@ mod tests {
             pub name: Option<String>,
         }
 
-        let m: Msg = crate::from_str(r#"{
+        let m: Msg = crate::from_str(
+            r#"{
           "name": "one"
-        }"#).expect("simple");
-        assert_eq!(m, Msg{name: "one".to_string()});
+        }"#,
+        )
+        .expect("simple");
+        assert_eq!(
+            m,
+            Msg {
+                name: "one".to_string()
+            }
+        );
 
-        let o: OptIn = crate::from_str(r#"{
+        let o: OptIn = crate::from_str(
+            r#"{
           "name": "two"
-        }"#).expect("opt");
-        assert_eq!(o, OptIn{name: Some("two".to_string())});
+        }"#,
+        )
+        .expect("opt");
+        assert_eq!(
+            o,
+            OptIn {
+                name: Some("two".to_string())
+            }
+        );
 
-        let res: Response = crate::from_str(r#"{
+        let res: Response = crate::from_str(
+            r#"{
           "log": "my log",
           "messages": [{"name": "one"}]
-        }"#).expect("fud");
-        assert_eq!(res, Response{
-            log: Some("my log".to_string()),
-            messages: vec![Msg{name: "one".to_string()}],
-        });
+        }"#,
+        )
+        .expect("fud");
+        assert_eq!(
+            res,
+            Response {
+                log: Some("my log".to_string()),
+                messages: vec![Msg {
+                    name: "one".to_string()
+                }],
+            }
+        );
 
         let res: Response = crate::from_str(r#"{"log": null,"messages": []}"#).expect("fud");
-        assert_eq!(res, Response{log: None, messages: Vec::new()});
+        assert_eq!(
+            res,
+            Response {
+                log: None,
+                messages: Vec::new()
+            }
+        );
     }
-
 
     #[test]
     fn deserialize_embedded_enum() {
@@ -936,7 +969,8 @@ mod tests {
             pub amount: Option<String>,
         }
 
-        let res: MyResult = crate::from_str(r#"{
+        let res: MyResult = crate::from_str(
+            r#"{
           "ok": {
             "log": "hello",
             "messages": [{
@@ -944,24 +978,53 @@ mod tests {
                 "amount": "15"
             }]
           }
-        }"#).expect("goo");
-        assert_eq!(res, MyResult::Ok(Response{log: Some("hello".to_string()), messages: vec![Msg{name: "fred".to_string(), amount: Some("15".to_string())}]}));
+        }"#,
+        )
+        .expect("goo");
+        assert_eq!(
+            res,
+            MyResult::Ok(Response {
+                log: Some("hello".to_string()),
+                messages: vec![Msg {
+                    name: "fred".to_string(),
+                    amount: Some("15".to_string())
+                }]
+            })
+        );
 
-        let res: MyResult= crate::from_str(r#"{
+        let res: MyResult = crate::from_str(
+            r#"{
           "ok": {
             "log": "hello",
             "messages": []
           }
-        }"#).expect("goo");
-        assert_eq!(res, MyResult::Ok(Response{log: Some("hello".to_string()), messages: Vec::new()}));
+        }"#,
+        )
+        .expect("goo");
+        assert_eq!(
+            res,
+            MyResult::Ok(Response {
+                log: Some("hello".to_string()),
+                messages: Vec::new()
+            })
+        );
 
-        let res: MyResult = crate::from_str(r#"{
+        let res: MyResult = crate::from_str(
+            r#"{
           "ok": {
             "log": null,
             "messages": []
           }
-        }"#).expect("goo");
-        assert_eq!(res, MyResult::Ok(Response{log: None, messages: Vec::new()}));
+        }"#,
+        )
+        .expect("goo");
+        assert_eq!(
+            res,
+            MyResult::Ok(Response {
+                log: None,
+                messages: Vec::new()
+            })
+        );
     }
 
     // See https://iot.mozilla.org/wot/#thing-resource

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -4,7 +4,7 @@ use std::{error, fmt, str::from_utf8};
 
 use serde::de::{self, Visitor};
 
-use self::enum_::{UnitVariantAccess, VariantAccess};
+use self::enum_::{StructVariantAccess, UnitVariantAccess};
 use self::map::MapAccess;
 use self::seq::SeqAccess;
 
@@ -610,14 +610,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             // if it is a struct enum
             b'{' => {
                 self.eat_char();
-                let value = visitor.visit_enum(VariantAccess::new(self))?;
-                match self.parse_whitespace().ok_or(Error::EofWhileParsingValue)? {
-                    b'}' => {
-                        self.eat_char();
-                        Ok(value)
-                    },
-                    _ => Err(Error::ExpectedSomeValue),
-                }
+                visitor.visit_enum(StructVariantAccess::new(self))
             },
             _ => Err(Error::ExpectedSomeIdent),
         }

--- a/src/de/seq.rs
+++ b/src/de/seq.rs
@@ -2,10 +2,7 @@ use serde::de;
 
 use crate::de::{Deserializer, Error, Result};
 
-pub(crate) struct SeqAccess<'a, 'b>
-where
-    'b: 'a,
-{
+pub(crate) struct SeqAccess<'a, 'b> {
     first: bool,
     de: &'a mut Deserializer<'b>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 #![deny(missing_docs)]
 #![deny(rust_2018_compatibility)]
 #![deny(rust_2018_idioms)]
-//#![deny(warnings)]
+#![deny(warnings)]
 
 pub mod de;
 pub mod ser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 #![deny(missing_docs)]
 #![deny(rust_2018_compatibility)]
 #![deny(rust_2018_idioms)]
-#![deny(warnings)]
+//#![deny(warnings)]
 
 pub mod de;
 pub mod ser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! [`serde-json`] for `no_std` programs
+//! [`serde-json`] for `wasm` programs
 //!
 //! [`serde-json`]: https://crates.io/crates/serde_json
 //!
@@ -57,7 +57,6 @@
 #![deny(rust_2018_compatibility)]
 #![deny(rust_2018_idioms)]
 #![deny(warnings)]
-#![no_std]
 
 pub mod de;
 pub mod ser;

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -129,7 +129,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     type SerializeTupleVariant = Unreachable;
     type SerializeMap = Unreachable;
     type SerializeStruct = SerializeStruct<'a>;
-    type SerializeStructVariant = Unreachable;
+    type SerializeStructVariant = SerializeStruct<'a>;
 
     fn serialize_bool(self, v: bool) -> Result<Self::Ok> {
         if v {
@@ -302,12 +302,15 @@ impl<'a> ser::Serializer for &'a mut Serializer {
 
     fn serialize_struct_variant(
         self,
-        _name: &'static str,
+        name: &'static str,
         _variant_index: u32,
-        _variant: &'static str,
-        _len: usize,
+        variant: &'static str,
+        len: usize,
     ) -> Result<Self::SerializeStructVariant> {
-        unreachable!()
+        self.buf.push(b'{');
+        self.serialize_str(variant)?;
+        self.buf.push(b':');
+        self.serialize_struct(name, len)
     }
 
     fn collect_str<T: ?Sized>(self, _value: &T) -> Result<Self::Ok>

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -232,15 +232,10 @@ impl<'a> ser::Serializer for &'a mut Serializer {
         self.serialize_str(variant)
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(
-        self,
-        _name: &'static str,
-        value: &T,
-    ) -> Result<Self::Ok>
+    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, value: &T) -> Result<Self::Ok>
     where
         T: ser::Serialize,
     {
-
         value.serialize(&mut *self)
     }
 
@@ -546,39 +541,54 @@ mod tests {
         );
     }
 
+    use serde_derive::Deserialize;
+
     #[test]
     fn serialize_embedded_enum() {
-        #[derive(Debug, Serialize, PartialEq)]
+        #[derive(Debug, Deserialize, Serialize, PartialEq)]
         #[serde(rename_all = "lowercase")]
         pub enum MyResult {
             Ok(Response),
             Err(String),
         }
 
-        #[derive(Debug, Serialize, PartialEq)]
+        #[derive(Debug, Deserialize, Serialize, PartialEq)]
         pub struct Response {
             pub log: Option<String>,
             pub count: i64,
             pub list: Vec<u32>,
         }
 
-        let json = crate::to_string(&MyResult::Err("some error".to_string())).expect("encode err enum");
+        let err_input = MyResult::Err("some error".to_string());
+        let json = crate::to_string(&err_input).expect("encode err enum");
         assert_eq!(json, r#"{"err":"some error"}"#.to_string());
+        let loaded = crate::from_str(&json).expect("re-load err enum");
+        assert_eq!(err_input, loaded);
 
-        let json = crate::to_string(&MyResult::Ok(Response {
+        let empty_list = MyResult::Ok(Response {
             log: Some("log message".to_string()),
             count: 137,
             list: Vec::new(),
-        })).expect("encode ok enum");
-        assert_eq!(json, r#"{"ok":{"log":"log message","count":137,"list":[]}}"#.to_string());
+        });
+        let json = crate::to_string(&empty_list).expect("encode ok enum");
+        assert_eq!(
+            json,
+            r#"{"ok":{"log":"log message","count":137,"list":[]}}"#.to_string()
+        );
+        let loaded = crate::from_str(&json).expect("re-load ok enum");
+        assert_eq!(empty_list, loaded);
 
-        let json = crate::to_string(&MyResult::Ok(Response {
+        let full_list = MyResult::Ok(Response {
             log: None,
             count: 137,
             list: vec![18u32, 34, 12],
-        })).expect("encode ok enum");
-        assert_eq!(json, r#"{"ok":{"log":null,"count":137,"list":[18,34,12]}}"#.to_string());
-
+        });
+        let json = crate::to_string(&full_list).expect("encode ok enum");
+        assert_eq!(
+            json,
+            r#"{"ok":{"log":null,"count":137,"list":[18,34,12]}}"#.to_string()
+        );
+        let loaded = crate::from_str(&json).expect("re-load ok enum");
+        assert_eq!(full_list, loaded);
     }
-
 }

--- a/src/ser/seq.rs
+++ b/src/ser/seq.rs
@@ -1,30 +1,19 @@
 use serde::ser;
 
-use heapless::ArrayLength;
-
 use crate::ser::{Error, Result, Serializer};
 
-pub struct SerializeSeq<'a, B>
-where
-    B: ArrayLength<u8>,
-{
-    de: &'a mut Serializer<B>,
+pub struct SerializeSeq<'a> {
+    de: &'a mut Serializer,
     first: bool,
 }
 
-impl<'a, B> SerializeSeq<'a, B>
-where
-    B: ArrayLength<u8>,
-{
-    pub(crate) fn new(de: &'a mut Serializer<B>) -> Self {
+impl<'a> SerializeSeq<'a> {
+    pub(crate) fn new(de: &'a mut Serializer) -> Self {
         SerializeSeq { de, first: true }
     }
 }
 
-impl<'a, B> ser::SerializeSeq for SerializeSeq<'a, B>
-where
-    B: ArrayLength<u8>,
-{
+impl<'a> ser::SerializeSeq for SerializeSeq<'a> {
     type Ok = ();
     type Error = Error;
 
@@ -33,7 +22,7 @@ where
         T: ser::Serialize,
     {
         if !self.first {
-            self.de.buf.push(b',')?;
+            self.de.buf.push(b',');
         }
         self.first = false;
 
@@ -42,15 +31,12 @@ where
     }
 
     fn end(self) -> Result<Self::Ok> {
-        self.de.buf.push(b']')?;
+        self.de.buf.push(b']');
         Ok(())
     }
 }
 
-impl<'a, B> ser::SerializeTuple for SerializeSeq<'a, B>
-where
-    B: ArrayLength<u8>,
-{
+impl<'a> ser::SerializeTuple for SerializeSeq<'a> {
     type Ok = ();
     type Error = Error;
 

--- a/src/ser/struct_.rs
+++ b/src/ser/struct_.rs
@@ -47,8 +47,8 @@ impl<'a> ser::SerializeStructVariant for SerializeStruct<'a> {
     type Error = Error;
 
     fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<()>
-        where
-            T: ser::Serialize,
+    where
+        T: ser::Serialize,
     {
         // XXX if `value` is `None` we not produce any output for this field
         if !self.first {

--- a/src/ser/struct_.rs
+++ b/src/ser/struct_.rs
@@ -1,30 +1,19 @@
 use serde::ser;
 
-use heapless::ArrayLength;
-
 use crate::ser::{Error, Result, Serializer};
 
-pub struct SerializeStruct<'a, B>
-where
-    B: ArrayLength<u8>,
-{
-    de: &'a mut Serializer<B>,
+pub struct SerializeStruct<'a> {
+    de: &'a mut Serializer,
     first: bool,
 }
 
-impl<'a, B> SerializeStruct<'a, B>
-where
-    B: ArrayLength<u8>,
-{
-    pub(crate) fn new(de: &'a mut Serializer<B>) -> Self {
+impl<'a> SerializeStruct<'a> {
+    pub(crate) fn new(de: &'a mut Serializer) -> Self {
         SerializeStruct { de, first: true }
     }
 }
 
-impl<'a, B> ser::SerializeStruct for SerializeStruct<'a, B>
-where
-    B: ArrayLength<u8>,
-{
+impl<'a> ser::SerializeStruct for SerializeStruct<'a> {
     type Ok = ();
     type Error = Error;
 
@@ -34,13 +23,13 @@ where
     {
         // XXX if `value` is `None` we not produce any output for this field
         if !self.first {
-            self.de.buf.push(b',')?;
+            self.de.buf.push(b',');
         }
         self.first = false;
 
-        self.de.buf.push(b'"')?;
-        self.de.buf.extend_from_slice(key.as_bytes())?;
-        self.de.buf.extend_from_slice(b"\":")?;
+        self.de.buf.push(b'"');
+        self.de.buf.extend_from_slice(key.as_bytes());
+        self.de.buf.extend_from_slice(b"\":");
 
         value.serialize(&mut *self.de)?;
 
@@ -48,7 +37,7 @@ where
     }
 
     fn end(self) -> Result<Self::Ok> {
-        self.de.buf.push(b'}')?;
+        self.de.buf.push(b'}');
         Ok(())
     }
 }

--- a/src/ser/struct_.rs
+++ b/src/ser/struct_.rs
@@ -41,3 +41,32 @@ impl<'a> ser::SerializeStruct for SerializeStruct<'a> {
         Ok(())
     }
 }
+
+impl<'a> ser::SerializeStructVariant for SerializeStruct<'a> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<()>
+        where
+            T: ser::Serialize,
+    {
+        // XXX if `value` is `None` we not produce any output for this field
+        if !self.first {
+            self.de.buf.push(b',');
+        }
+        self.first = false;
+
+        self.de.buf.push(b'"');
+        self.de.buf.extend_from_slice(key.as_bytes());
+        self.de.buf.extend_from_slice(b"\":");
+
+        value.serialize(&mut *self.de)?;
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        self.de.buf.push(b'}');
+        Ok(())
+    }
+}


### PR DESCRIPTION
This adds support for serializing and deserializing more complex structs as I use in my app. This does add some code-size unfortunately, but gives us the full expressiveness of serde-json.

It let's us handle structs like this:

```rust
pub enum ContractResult {
    Ok(Response),
    Err(String),
}

#[derive(Serialize, Deserialize, Default)]
pub struct Response {
    pub messages: Vec<CosmosMsg>,
    pub log: Option<String>,
    pub data: Option<String>,
}

#[derive(Serialize, Deserialize)]
#[serde(rename_all = "lowercase")]
pub enum CosmosMsg {
    Send {
        from_address: String,
        to_address: String,
        amount: Vec<Coin>,
    },
    Contract {
        contract_addr: String,
        msg: String,
    },
    Opaque {
        data: String,
    },
}
```