### PR TITLE
Fix embeded enums

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,25 +1,18 @@
 [package]
-authors = ["Jorge Aparicio <jorge@japaric.io>"]
-categories = ["no-std"]
-description = "serde-json for no_std programs"
-documentation = "https://docs.rs/serde-json-core"
+authors = ["Jorge Aparicio <jorge@japaric.io>", "Ethan Frey <ethanfrey@noreply.github.com"]
+categories = ["wasm"]
+description = "serde-json for wasm programs"
+documentation = "https://docs.rs/serde-json-wasm"
 edition = "2018"
-keywords = ["serde", "json"]
+keywords = ["serde", "json", "wasm"]
 license = "MIT OR Apache-2.0"
-name = "serde-json-core"
+name = "serde-json-wasm"
 readme = "README.md"
-repository = "https://japaric.github.io/serde-json-core/serde_json_core"
-version = "0.0.1"
+repository = "https://github.com/confio/serde-json-wasm"
+version = "0.1.0"
 
 [dependencies]
-heapless = "0.4.0"
-
-[dependencies.serde]
-default-features = false
-version = "1.0.80"
+serde = {version = "^1.0.80", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-serde_derive = "1.0.80"
-
-[features]
-std = ["serde/std"]
+serde_derive = "^1.0.80"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ name = "serde-json-wasm"
 readme = "README.md"
 repository = "https://github.com/confio/serde-json-wasm"
 version = "0.1.0"
+exclude = ["ci/*", ".gitignore", ".cargo", ".travis.yml"]
 
 [dependencies]
 serde = {version = "^1.0.80", default-features = false, features = ["alloc"] }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,0 @@
-nightly

--- a/src/de/enum_.rs
+++ b/src/de/enum_.rs
@@ -2,10 +2,7 @@ use serde::de;
 
 use crate::de::{Deserializer, Error, Result};
 
-pub(crate) struct UnitVariantAccess<'a, 'b>
-where
-    'b: 'a,
-{
+pub(crate) struct UnitVariantAccess<'a, 'b> {
     de: &'a mut Deserializer<'b>,
 }
 

--- a/src/de/enum_.rs
+++ b/src/de/enum_.rs
@@ -53,3 +53,68 @@ impl<'de, 'a> de::VariantAccess<'de> for UnitVariantAccess<'a, 'de> {
         Err(Error::InvalidType)
     }
 }
+
+pub(crate) struct StructVariantAccess<'a, 'b> {
+    de: &'a mut Deserializer<'b>,
+}
+
+impl<'a, 'b> StructVariantAccess<'a, 'b> {
+    pub fn new(de: &'a mut Deserializer<'b>) -> Self {
+        StructVariantAccess { de: de }
+    }
+}
+
+impl<'a, 'de> de::EnumAccess<'de> for StructVariantAccess<'a, 'de> {
+    type Error = Error;
+    type Variant = Self;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self)>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        let val = seed.deserialize(&mut *self.de)?;
+        self.de.parse_object_colon()?;
+        Ok((val, self))
+    }
+}
+
+impl<'a, 'de> de::VariantAccess<'de> for StructVariantAccess<'a, 'de> {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<()> {
+        Err(Error::InvalidType)
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        let value = seed.deserialize(&mut *self.de)?;
+        // we remove trailing '}' to be consistent with struct_variant algorithm
+        match self
+            .de
+            .parse_whitespace()
+            .ok_or(Error::EofWhileParsingValue)?
+        {
+            b'}' => {
+                self.de.eat_char();
+                Ok(value)
+            }
+            _ => Err(Error::ExpectedSomeValue),
+        }
+    }
+
+    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value>
+    where
+        V: de::Visitor<'de>,
+    {
+        Err(Error::InvalidType)
+    }
+
+    fn struct_variant<V>(self, fields: &'static [&'static str], visitor: V) -> Result<V::Value>
+    where
+        V: de::Visitor<'de>,
+    {
+        de::Deserializer::deserialize_struct(self.de, "", fields, visitor)
+    }
+}

--- a/src/de/enum_.rs
+++ b/src/de/enum_.rs
@@ -115,6 +115,17 @@ impl<'a, 'de> de::VariantAccess<'de> for StructVariantAccess<'a, 'de> {
     where
         V: de::Visitor<'de>,
     {
-        de::Deserializer::deserialize_struct(self.de, "", fields, visitor)
+        let value = de::Deserializer::deserialize_struct(&mut *self.de, "", fields, visitor)?;
+        match self
+            .de
+            .parse_whitespace()
+            .ok_or(Error::EofWhileParsingValue)?
+            {
+                b'}' => {
+                    self.de.eat_char();
+                    Ok(value)
+                }
+                _ => Err(Error::ExpectedSomeValue),
+            }
     }
 }

--- a/src/de/map.rs
+++ b/src/de/map.rs
@@ -2,10 +2,7 @@ use serde::de::{self, Visitor};
 
 use crate::de::{Deserializer, Error};
 
-pub struct MapAccess<'a, 'b>
-where
-    'b: 'a,
-{
+pub struct MapAccess<'a, 'b> {
     de: &'a mut Deserializer<'b>,
     first: bool,
 }
@@ -60,10 +57,7 @@ impl<'a, 'de> de::MapAccess<'de> for MapAccess<'a, 'de> {
     }
 }
 
-struct MapKey<'a, 'b>
-where
-    'b: 'a,
-{
+struct MapKey<'a, 'b> {
     de: &'a mut Deserializer<'b>,
 }
 
@@ -289,10 +283,12 @@ impl<'de, 'a> de::Deserializer<'de> for MapKey<'a, 'de> {
         self.deserialize_str(visitor)
     }
 
-    fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        unreachable!()
+        // Even if we’re ignoring the contents of the map, we still need to
+        // deserialize the string here in order to chomp the key’s characters.
+        self.deserialize_str(visitor)
     }
 }

--- a/src/de/seq.rs
+++ b/src/de/seq.rs
@@ -2,10 +2,7 @@ use serde::de;
 
 use crate::de::{Deserializer, Error, Result};
 
-pub(crate) struct SeqAccess<'a, 'b>
-where
-    'b: 'a,
-{
+pub(crate) struct SeqAccess<'a, 'b> {
     first: bool,
     de: &'a mut Deserializer<'b>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! [`serde-json`] for `no_std` programs
+//! [`serde-json`] for `wasm` programs
 //!
 //! [`serde-json`]: https://crates.io/crates/serde_json
 //!
@@ -57,7 +57,6 @@
 #![deny(rust_2018_compatibility)]
 #![deny(rust_2018_idioms)]
 #![deny(warnings)]
-#![no_std]
 
 pub mod de;
 pub mod ser;

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -129,7 +129,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     type SerializeTupleVariant = Unreachable;
     type SerializeMap = Unreachable;
     type SerializeStruct = SerializeStruct<'a>;
-    type SerializeStructVariant = Unreachable;
+    type SerializeStructVariant = SerializeStruct<'a>;
 
     fn serialize_bool(self, v: bool) -> Result<Self::Ok> {
         if v {
@@ -232,28 +232,29 @@ impl<'a> ser::Serializer for &'a mut Serializer {
         self.serialize_str(variant)
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(
-        self,
-        _name: &'static str,
-        _value: &T,
-    ) -> Result<Self::Ok>
+    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, value: &T) -> Result<Self::Ok>
     where
         T: ser::Serialize,
     {
-        unreachable!()
+        value.serialize(&mut *self)
     }
 
     fn serialize_newtype_variant<T: ?Sized>(
         self,
         _name: &'static str,
         _variant_index: u32,
-        _variant: &'static str,
-        _value: &T,
+        variant: &'static str,
+        value: &T,
     ) -> Result<Self::Ok>
     where
         T: ser::Serialize,
     {
-        unreachable!()
+        self.buf.push(b'{');
+        self.serialize_str(variant)?;
+        self.buf.push(b':');
+        value.serialize(&mut *self)?;
+        self.buf.push(b'}');
+        Ok(())
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
@@ -296,12 +297,15 @@ impl<'a> ser::Serializer for &'a mut Serializer {
 
     fn serialize_struct_variant(
         self,
-        _name: &'static str,
+        name: &'static str,
         _variant_index: u32,
-        _variant: &'static str,
-        _len: usize,
+        variant: &'static str,
+        len: usize,
     ) -> Result<Self::SerializeStructVariant> {
-        unreachable!()
+        self.buf.push(b'{');
+        self.serialize_str(variant)?;
+        self.buf.push(b':');
+        self.serialize_struct(name, len)
     }
 
     fn collect_str<T: ?Sized>(self, _value: &T) -> Result<Self::Ok>
@@ -535,5 +539,56 @@ mod tests {
             &*crate::to_string(&Tuple { a: true, b: false }).unwrap(),
             r#"{"a":true,"b":false}"#
         );
+    }
+
+    use serde_derive::Deserialize;
+
+    #[test]
+    fn serialize_embedded_enum() {
+        #[derive(Debug, Deserialize, Serialize, PartialEq)]
+        #[serde(rename_all = "lowercase")]
+        pub enum MyResult {
+            Ok(Response),
+            Err(String),
+        }
+
+        #[derive(Debug, Deserialize, Serialize, PartialEq)]
+        pub struct Response {
+            pub log: Option<String>,
+            pub count: i64,
+            pub list: Vec<u32>,
+        }
+
+        let err_input = MyResult::Err("some error".to_string());
+        let json = crate::to_string(&err_input).expect("encode err enum");
+        assert_eq!(json, r#"{"err":"some error"}"#.to_string());
+        let loaded = crate::from_str(&json).expect("re-load err enum");
+        assert_eq!(err_input, loaded);
+
+        let empty_list = MyResult::Ok(Response {
+            log: Some("log message".to_string()),
+            count: 137,
+            list: Vec::new(),
+        });
+        let json = crate::to_string(&empty_list).expect("encode ok enum");
+        assert_eq!(
+            json,
+            r#"{"ok":{"log":"log message","count":137,"list":[]}}"#.to_string()
+        );
+        let loaded = crate::from_str(&json).expect("re-load ok enum");
+        assert_eq!(empty_list, loaded);
+
+        let full_list = MyResult::Ok(Response {
+            log: None,
+            count: 137,
+            list: vec![18u32, 34, 12],
+        });
+        let json = crate::to_string(&full_list).expect("encode ok enum");
+        assert_eq!(
+            json,
+            r#"{"ok":{"log":null,"count":137,"list":[18,34,12]}}"#.to_string()
+        );
+        let loaded = crate::from_str(&json).expect("re-load ok enum");
+        assert_eq!(full_list, loaded);
     }
 }

--- a/src/ser/seq.rs
+++ b/src/ser/seq.rs
@@ -1,30 +1,19 @@
 use serde::ser;
 
-use heapless::ArrayLength;
-
 use crate::ser::{Error, Result, Serializer};
 
-pub struct SerializeSeq<'a, B>
-where
-    B: ArrayLength<u8>,
-{
-    de: &'a mut Serializer<B>,
+pub struct SerializeSeq<'a> {
+    de: &'a mut Serializer,
     first: bool,
 }
 
-impl<'a, B> SerializeSeq<'a, B>
-where
-    B: ArrayLength<u8>,
-{
-    pub(crate) fn new(de: &'a mut Serializer<B>) -> Self {
+impl<'a> SerializeSeq<'a> {
+    pub(crate) fn new(de: &'a mut Serializer) -> Self {
         SerializeSeq { de, first: true }
     }
 }
 
-impl<'a, B> ser::SerializeSeq for SerializeSeq<'a, B>
-where
-    B: ArrayLength<u8>,
-{
+impl<'a> ser::SerializeSeq for SerializeSeq<'a> {
     type Ok = ();
     type Error = Error;
 
@@ -33,7 +22,7 @@ where
         T: ser::Serialize,
     {
         if !self.first {
-            self.de.buf.push(b',')?;
+            self.de.buf.push(b',');
         }
         self.first = false;
 
@@ -42,15 +31,12 @@ where
     }
 
     fn end(self) -> Result<Self::Ok> {
-        self.de.buf.push(b']')?;
+        self.de.buf.push(b']');
         Ok(())
     }
 }
 
-impl<'a, B> ser::SerializeTuple for SerializeSeq<'a, B>
-where
-    B: ArrayLength<u8>,
-{
+impl<'a> ser::SerializeTuple for SerializeSeq<'a> {
     type Ok = ();
     type Error = Error;
 

--- a/src/ser/struct_.rs
+++ b/src/ser/struct_.rs
@@ -66,6 +66,9 @@ impl<'a> ser::SerializeStructVariant for SerializeStruct<'a> {
     }
 
     fn end(self) -> Result<Self::Ok> {
+        // close struct
+        self.de.buf.push(b'}');
+        // close surrounding enum
         self.de.buf.push(b'}');
         Ok(())
     }

--- a/src/ser/struct_.rs
+++ b/src/ser/struct_.rs
@@ -1,30 +1,19 @@
 use serde::ser;
 
-use heapless::ArrayLength;
-
 use crate::ser::{Error, Result, Serializer};
 
-pub struct SerializeStruct<'a, B>
-where
-    B: ArrayLength<u8>,
-{
-    de: &'a mut Serializer<B>,
+pub struct SerializeStruct<'a> {
+    de: &'a mut Serializer,
     first: bool,
 }
 
-impl<'a, B> SerializeStruct<'a, B>
-where
-    B: ArrayLength<u8>,
-{
-    pub(crate) fn new(de: &'a mut Serializer<B>) -> Self {
+impl<'a> SerializeStruct<'a> {
+    pub(crate) fn new(de: &'a mut Serializer) -> Self {
         SerializeStruct { de, first: true }
     }
 }
 
-impl<'a, B> ser::SerializeStruct for SerializeStruct<'a, B>
-where
-    B: ArrayLength<u8>,
-{
+impl<'a> ser::SerializeStruct for SerializeStruct<'a> {
     type Ok = ();
     type Error = Error;
 
@@ -34,13 +23,13 @@ where
     {
         // XXX if `value` is `None` we not produce any output for this field
         if !self.first {
-            self.de.buf.push(b',')?;
+            self.de.buf.push(b',');
         }
         self.first = false;
 
-        self.de.buf.push(b'"')?;
-        self.de.buf.extend_from_slice(key.as_bytes())?;
-        self.de.buf.extend_from_slice(b"\":")?;
+        self.de.buf.push(b'"');
+        self.de.buf.extend_from_slice(key.as_bytes());
+        self.de.buf.extend_from_slice(b"\":");
 
         value.serialize(&mut *self.de)?;
 
@@ -48,7 +37,7 @@ where
     }
 
     fn end(self) -> Result<Self::Ok> {
-        self.de.buf.push(b'}')?;
+        self.de.buf.push(b'}');
         Ok(())
     }
 }

--- a/src/ser/struct_.rs
+++ b/src/ser/struct_.rs
@@ -41,3 +41,32 @@ impl<'a> ser::SerializeStruct for SerializeStruct<'a> {
         Ok(())
     }
 }
+
+impl<'a> ser::SerializeStructVariant for SerializeStruct<'a> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ser::Serialize,
+    {
+        // XXX if `value` is `None` we not produce any output for this field
+        if !self.first {
+            self.de.buf.push(b',');
+        }
+        self.first = false;
+
+        self.de.buf.push(b'"');
+        self.de.buf.extend_from_slice(key.as_bytes());
+        self.de.buf.extend_from_slice(b"\":");
+
+        value.serialize(&mut *self.de)?;
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        self.de.buf.push(b'}');
+        Ok(())
+    }
+}


### PR DESCRIPTION
We were missing a trailing } both in de and ser when parsing (non-newtype / embedded) enum structs. It was symetrical, but not valid json.

Now this is fixed, and compatible with typical parsers.