### PR TITLE
Disable no_std when the std feature is present

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@
 #![deny(rust_2018_compatibility)]
 #![deny(rust_2018_idioms)]
 #![deny(warnings)]
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod de;
 pub mod ser;


### PR DESCRIPTION
This is for example needed when implementing the `std::error::Error` trait which is only possible if the `std` crate is available